### PR TITLE
Add InfoSecLabs to Blue Team and DFIR section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
 
 ## Blue Team and DFIR
 
+- [InfoSecLabs](https://infoseclabs.io/) - Hands-on SOC analyst training platform with real-world breach investigations, 108+ CTF challenges across 8 categories, enterprise SOC tools (Splunk, Wazuh, CrowdStrike), and AI-driven mentorship.
+
 - [Blue Team Labs by Cyberdefenders](https://cyberdefenders.org/blueteam-ctf-challenges/) - Put your knowledge into practice with gamified cyber security challenges.
 - [LetsDefend](https://app.letsdefend.io/) - Hands-On Blue Team Training with hands-on experience by investigating real cyber attacks inside a simulated SOC.
 - [Computer Forensic Reference DataSet Portal](https://cfreds.nist.gov/) - This portal is your gateway to documented digital forensic image datasets.  

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@
 ## Blue Team and DFIR
 
 - [InfoSecLabs](https://infoseclabs.io/) - Hands-on SOC analyst training platform with real-world breach investigations, 108+ CTF challenges across 8 categories, enterprise SOC tools (Splunk, Wazuh, CrowdStrike), and AI-driven mentorship.
-
 - [Blue Team Labs by Cyberdefenders](https://cyberdefenders.org/blueteam-ctf-challenges/) - Put your knowledge into practice with gamified cyber security challenges.
 - [LetsDefend](https://app.letsdefend.io/) - Hands-On Blue Team Training with hands-on experience by investigating real cyber attacks inside a simulated SOC.
 - [Computer Forensic Reference DataSet Portal](https://cfreds.nist.gov/) - This portal is your gateway to documented digital forensic image datasets.  


### PR DESCRIPTION
Adds [InfoSecLabs](https://infoseclabs.io) - a hands-on SOC analyst training platform for blue team skill development. Features real-world breach investigations, 108+ CTF challenges, enterprise SOC tools (Splunk, Wazuh, CrowdStrike), and AI-driven mentorship.