### PR TITLE
Add RansomLeak to platforms for improving hacking skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@
 - [Hackviser](https://hackviser.com/) - A cybersecurity upskilling platform with training, scenarios, labs, and warm-ups.
 - [Newbie Contest](https://www.newbiecontest.org/) - Tailored cybersecurity upskilling platform for all levels.
 - [Over The Wire](https://overthewire.org/wargames/) - The wargames can help you to learn and practice security concepts.
-- [PentesterLab](https://pentesterlab.com/) - Platform for learning and help level up skill on Web Hacking. 
+- [PentesterLab](https://pentesterlab.com/) - Platform for learning and help level up skill on Web Hacking.
+- [RansomLeak](https://ransomleak.com/catalogue/application-security/) - Interactive browser-based platform covering Application Security, API Security, Cloud Security, Git Security, and AI Security with hands-on labs based on OWASP Top 10. 
 - [Pwnable.kr](http://pwnable.kr/) - Provides various pwn challenges regarding system exploitation. You need some skills regarding programming, reverse-engineering, bug exploitation, system knowledge, cryptography.
 - [Pwnable.tw](https://pwnable.tw/) - Wargame site to test and expand binary exploitation skills.
 - [Research Labs](https://researchlabs.tech/) - A technical platform dedicated for learning and practicing technological research.


### PR DESCRIPTION
Added [RansomLeak](https://ransomleak.com/catalogue/application-security/) to the **Platforms to Improve Hacking Skills** section, in line with other similar training platforms like PentesterLab and HackTheBox.

RansomLeak provides interactive browser-based hands-on training covering:
- Application Security (OWASP Top 10)
- API Security
- Cloud Security (AWS/GCP/Azure misconfigurations)
- Git/Secrets Security
- AI Security (LLM attacks, prompt injection)

No installation required, and covers attack/defense scenarios with real-world examples.

Disclosure: I work on RansomLeak. Formatting matches the surrounding entries and all URLs return 200.

https://claude.ai/code/session_01HGMArmtREp8pabSevihxCz